### PR TITLE
Refactoring SITs for kubecf compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# sync-tests-release
-BOSH Release for the Cloud Foundry [Sync Tests](https://github.com/cloudfoundry/sync-integration-tests) for Kube CF
+# sync-integration-tests-release
+BOSH Release for the Cloud Foundry [Sync Integration Tests](https://github.com/cloudfoundry/sync-integration-tests) for Kube CF

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -3,8 +3,7 @@ cli/cf-cli_6.42.0_linux_x86-64.tgz:
   object_id: cf-cli_6.42.0_linux_x86-64.tgz
   sha: 8cde11d372b6a022c101e78df1a563cd5d034269
   size: 7361332
-golang/go1.10.linux-amd64.tar.gz:
-  size: 119905205
-  object_id: go1.10.linux-amd64.tar.gz
-  sha: 693e2dfd99ef2d608b41c450efd9d277bf2a7f2f
-
+golang/go1.13.7.linux-amd64.tar.gz:
+  size: 120071076
+  object_id: go1.13.7.linux-amd64.tar.gz
+  sha: sha256:b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,5 +1,5 @@
 ---
-final_name: scf
+final_name: sync-integration-tests
 min_cli_version: 1.5.0.pre.1001
 blobstore:
   provider: s3

--- a/jobs/sync-integration-tests/spec
+++ b/jobs/sync-integration-tests/spec
@@ -5,7 +5,7 @@ description: "The sync integration tests errand can be configured to run full sy
 
 packages:
   - sync-integration-tests
-  - golang1.10
+  - golang1
   - cli
   - kubectl
 

--- a/jobs/sync-integration-tests/spec
+++ b/jobs/sync-integration-tests/spec
@@ -15,6 +15,8 @@ templates:
   pre-start.erb: bin/pre-start
   run.erb: bin/run
   bpm.yml.erb: config/bpm.yml
+  bbs_client_cert.erb: bin/bbs_client_cert
+  bbs_client_key.erb: bin/bbs_client_key
 
 properties:
   sync_integration_tests.setup.flake_attempts:

--- a/jobs/sync-integration-tests/spec
+++ b/jobs/sync-integration-tests/spec
@@ -14,6 +14,7 @@ templates:
   port_forwarding.erb: bin/port_forwarding
   pre-start.erb: bin/pre-start
   run.erb: bin/run
+  bpm.yml.erb: config/bpm.yml
 
 properties:
   sync_integration_tests.setup.flake_attempts:

--- a/jobs/sync-integration-tests/templates/bbs_client_cert.erb
+++ b/jobs/sync-integration-tests/templates/bbs_client_cert.erb
@@ -1,0 +1,1 @@
+<%= p('sync_integration_tests.config.bbs_client_cert_contents') %>

--- a/jobs/sync-integration-tests/templates/bbs_client_key.erb
+++ b/jobs/sync-integration-tests/templates/bbs_client_key.erb
@@ -1,0 +1,1 @@
+<%= p('sync_integration_tests.config.bbs_client_key_contents') %>

--- a/jobs/sync-integration-tests/templates/bpm.yml.erb
+++ b/jobs/sync-integration-tests/templates/bpm.yml.erb
@@ -1,0 +1,4 @@
+processes:
+  - name: sync-integration-tests
+    executable: /var/vcap/jobs/sync-integration-tests/bin/run
+    ephemeral_disk: true

--- a/jobs/sync-integration-tests/templates/config.json.erb
+++ b/jobs/sync-integration-tests/templates/config.json.erb
@@ -2,12 +2,8 @@
   require 'json'
   config = p('sync_integration_tests.config')
 
-  bbs_client_cert_contents = "/tmp/bbs_client_cert"
-  bbs_client_key_contents = "/tmp/bbs_client_key"
-  config[:bbs_client_cert] = bbs_client_cert_contents
-  config[:bbs_client_key] = bbs_client_key_contents
-  File.write(bbs_client_cert_contents, config.fetch("bbs_client_cert_contents"))
-  File.write(bbs_client_key_contents, config.fetch("bbs_client_key_contents"))
+  config[:bbs_client_cert] = "/var/vcap/jobs/sync-integration-tests/bin/bbs_client_cert"
+  config[:bbs_client_key] = "/var/vcap/jobs/sync-integration-tests/bin/bbs_client_key"
   config.delete("bbs_client_cert_contents")
   config.delete("bbs_client_key_contents")
 

--- a/jobs/sync-integration-tests/templates/pre-start.erb
+++ b/jobs/sync-integration-tests/templates/pre-start.erb
@@ -1,15 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/sh
+<% require 'shellwords' %>
 
 set -o errexit
 set -o nounset
 
-PATH="/var/vcap/packages/cli/bin:${PATH}"
+PATH=$PATH:/var/vcap/packages/cli/bin
 
-cf api --skip-ssl-validation "https://api.${DOMAIN}"
-cf auth admin "${CLUSTER_ADMIN_PASSWORD}"
+cf api --skip-ssl-validation \
+   https://<%= properties.sync_integration_tests.config.cf_api.shellescape %>
+
+cf auth \
+   <%= properties.sync_integration_tests.config.cf_admin_user.shellescape %> \
+   <%= properties.sync_integration_tests.config.cf_admin_password.shellescape %>
 
 # Allow connections to ourselves.
-IP="$(host "api.${DOMAIN}" | tail -n1 | awk '{ print $NF }')"
+IP="$(host <%= properties.sync_integration_tests.config.cf_api.shellescape %> | tail -n1 | awk '{ print $NF }')"
 if test -n "${IP}" && test -z "${IP//[0-9.]/}" ; then
     # We have an address for hairpin to the cluster endpoint.
     cf create-security-group loopback <(echo "[{\"destination\":\"${IP}\",\"protocol\":\"all\"}]")

--- a/jobs/sync-integration-tests/templates/pre-start.erb
+++ b/jobs/sync-integration-tests/templates/pre-start.erb
@@ -17,7 +17,8 @@ cf auth \
 IP="$(host <%= properties.sync_integration_tests.config.cf_api.shellescape %> | tail -n1 | awk '{ print $NF }')"
 if test -n "${IP}" && test -z "${IP//[0-9.]/}" ; then
     # We have an address for hairpin to the cluster endpoint.
-    cf create-security-group loopback <(echo "[{\"destination\":\"${IP}\",\"protocol\":\"all\"}]")
+    echo "[{\"destination\":\"${IP}\",\"protocol\":\"all\"}]" > rules.json
+    cf create-security-group loopback rules.json
     cf bind-staging-security-group loopback
     cf bind-running-security-group loopback
 fi

--- a/jobs/sync-integration-tests/templates/run.erb
+++ b/jobs/sync-integration-tests/templates/run.erb
@@ -5,7 +5,7 @@ set -o errexit
 export PATH="/var/vcap/packages/cli/bin:${PATH}"
 export PATH="/var/vcap/packages/kubectl/bin:${PATH}"
 
-GOROOT="$(readlink -nf /var/vcap/packages/golang1.10)"
+GOROOT="$(readlink -nf /var/vcap/packages/golang*)"
 export GOROOT
 export PATH="${GOROOT}/bin:${PATH}"
 

--- a/packages/golang1.10/spec
+++ b/packages/golang1.10/spec
@@ -1,7 +1,0 @@
----
-name: golang1.10
-
-dependencies: []
-
-files:
-    - golang/go1.10.linux-amd64.tar.gz

--- a/packages/golang1/packaging
+++ b/packages/golang1/packaging
@@ -2,5 +2,5 @@
 
 set -e
 
-tar xzf golang/go1.10.linux-amd64.tar.gz
+tar xzf golang/go1.13.7.linux-amd64.tar.gz
 cp -R go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang1/spec
+++ b/packages/golang1/spec
@@ -1,0 +1,7 @@
+---
+name: golang1
+
+dependencies: []
+
+files:
+    - golang/go1.13.7.linux-amd64.tar.gz

--- a/packages/sync-integration-tests/packaging
+++ b/packages/sync-integration-tests/packaging
@@ -8,7 +8,7 @@ cp -a . ${BOSH_INSTALL_TARGET}/src
 
 export PATH="/var/vcap/packages/git/bin:${PATH}"
 
-GOROOT="$(readlink -nf /var/vcap/packages/golang1.10)"
+GOROOT="$(readlink -nf /var/vcap/packages/golang*)"
 export GOROOT
 export PATH="${GOROOT}/bin:${PATH}"
 export GOPATH="/var/vcap/packages/sync-integration-tests"

--- a/packages/sync-integration-tests/spec
+++ b/packages/sync-integration-tests/spec
@@ -3,7 +3,7 @@ name: sync-integration-tests
 dependencies:
   - cli
   - git
-  - golang1.10
+  - golang1
 files:
   - code.cloudfoundry.org/sync-integration-tests/**/*
 excluded_files:


### PR DESCRIPTION
This PR intends to add changes to the SITs bosh release in order to make it ready to be consumed in [kubecf](https://github.com/SUSE/kubecf/pull/404).